### PR TITLE
make histograms be available behind a flag, remove `code` from them

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
+
 // UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
 func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	monitor := newServerReporter(Unary, info.FullMethod)


### PR DESCRIPTION
Addresses histogram and code issues from:
https://github.com/mwitkow/go-grpc-prometheus/issues/2
